### PR TITLE
Adjust for Flask 0.11 deprecations and fix issue with Python 3

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from collections import Counter
 
 from flask import Flask, render_template, jsonify
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.sql import func
 from flask_bootstrap import Bootstrap
 

--- a/weather.py
+++ b/weather.py
@@ -111,8 +111,8 @@ class Sensor(db.Model):
         if length == 0:
             return 0
         if not length % 2:
-            return (s[length / 2] + s[length / 2] - 1) / 2
-        return s[length / 2]
+            return (s[int(length / 2)] + s[int(length / 2)] - 1) / 2
+        return s[int(length / 2)]
 
     @staticmethod
     def _round_to_hour(dt):


### PR DESCRIPTION
In Python 3 all divisions between int values result in a float which
can't be used as index. Therefore adjust the code to cast the calculation
result to an int.